### PR TITLE
Fix ambiguous curl option error for --compress

### DIFF
--- a/check
+++ b/check
@@ -37,7 +37,7 @@ function monitor {
 
       # -w "$GREEN%{http_code}$RESET $url \\033[${p};${TIMING_COL}f%{time_total}s TTFB: %{time_connect} + %{time_starttransfer} (%{size_download})" \
 
-  echo -e "\033[${p};0f$(curl ${CURL_ARGS} $url --compress -s -o /dev/null -w \
+  echo -e "\033[${p};0f$(curl ${CURL_ARGS} $url --compressed -s -o /dev/null -w \
     "%{http_code}|%{time_total}|%{time_pretransfer}|%{time_starttransfer}\n"\
       | sed -n '/^/ s///p' \
       | while IFS='|' read http_code time_total time_pretransfer time_starttransfer;


### PR DESCRIPTION
In as low as curl 7.58.0 (as far as  know [possibly earlier]) `--compress` is not a valid option and results in:

`curl: option --compress: is ambiguous`

Proposed change...

From (line 40):

`echo -e "\033[${p};0f$(curl ${CURL_ARGS} $url --compress -s -o /dev/null -w \`

To  (line 40):

`echo -e "\033[${p};0f$(curl ${CURL_ARGS} $url --compressed -s -o /dev/null -w \`

See: https://curl.haxx.se/docs/manpage.html

If you need to support the `--compress` arg, perhaps a version check on curl might suffice.

Tested on:

- Windows 10
- Ubuntu 18.04

Otherwise script works quite nicely. Thanks for your contribution.